### PR TITLE
Move email / social / picture / resume to PUBLIC_* env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy to .env and fill in your values.
+# These are PUBLIC — they're inlined into the static build and visible
+# in the shipped HTML. Do not put secrets here.
+
+# Bare email address (code wraps it in mailto:)
+PUBLIC_EMAIL=you@example.com
+
+# Full profile URLs
+PUBLIC_GITHUB_URL=https://github.com/your-handle
+PUBLIC_LINKEDIN_URL=https://www.linkedin.com/in/your-handle/
+
+# Optional — leave empty to fall back to the "SR" initials placeholder
+PUBLIC_PROFILE_PICTURE_URL=
+
+# Optional — leave empty to hide the Resume download button
+PUBLIC_RESUME_URL=

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,3 +17,9 @@ jobs:
               run: npm run lint
             - name: Build
               run: npm run build
+              env:
+                  PUBLIC_EMAIL: ${{ vars.PUBLIC_EMAIL }}
+                  PUBLIC_GITHUB_URL: ${{ vars.PUBLIC_GITHUB_URL }}
+                  PUBLIC_LINKEDIN_URL: ${{ vars.PUBLIC_LINKEDIN_URL }}
+                  PUBLIC_PROFILE_PICTURE_URL: ${{ vars.PUBLIC_PROFILE_PICTURE_URL }}
+                  PUBLIC_RESUME_URL: ${{ vars.PUBLIC_RESUME_URL }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,12 @@ jobs:
               run: npm ci
             - name: Build
               run: npm run build
+              env:
+                  PUBLIC_EMAIL: ${{ vars.PUBLIC_EMAIL }}
+                  PUBLIC_GITHUB_URL: ${{ vars.PUBLIC_GITHUB_URL }}
+                  PUBLIC_LINKEDIN_URL: ${{ vars.PUBLIC_LINKEDIN_URL }}
+                  PUBLIC_PROFILE_PICTURE_URL: ${{ vars.PUBLIC_PROFILE_PICTURE_URL }}
+                  PUBLIC_RESUME_URL: ${{ vars.PUBLIC_RESUME_URL }}
             - name: Setup Pages
               uses: actions/configure-pages@v5
             - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 build
 node_modules
 .DS_Store
+
+# Local env — copy .env.example to .env and fill in your values.
+.env
+.env.*
+!.env.example

--- a/src/lib/components/Contact.svelte
+++ b/src/lib/components/Contact.svelte
@@ -14,7 +14,9 @@
                 product you're trying to ship well.
             </p>
             <div class="actions">
-                <a class="btn primary" href={site.social.email}>Say hello</a>
+                {#if site.social.email}
+                    <a class="btn primary" href={site.social.email}>Say hello</a>
+                {/if}
                 <SocialIcons links={site.social} variant="ghost" />
             </div>
         </div>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -23,7 +23,9 @@
                         /></svg
                     >
                 </a>
-                <a class="btn ghost" href={site.social.email}>Get in Touch</a>
+                {#if site.social.email}
+                    <a class="btn ghost" href={site.social.email}>Get in Touch</a>
+                {/if}
             </div>
             <div class="meta">
                 <SocialIcons links={site.social} />
@@ -34,9 +36,19 @@
             </div>
         </div>
         <aside class="portrait">
-            <div class="photo" role="img" aria-label="Profile portrait placeholder">
-                <span class="initials">SR</span>
-            </div>
+            {#if site.profilePicture}
+                <img
+                    class="photo"
+                    src={site.profilePicture}
+                    alt="{site.name} — profile portrait"
+                    loading="eager"
+                    decoding="async"
+                />
+            {:else}
+                <div class="photo" role="img" aria-label="Profile portrait placeholder">
+                    <span class="initials">SR</span>
+                </div>
+            {/if}
         </aside>
     </div>
     <div class="beam" aria-hidden="true"></div>
@@ -184,6 +196,11 @@
         display: grid;
         place-items: center;
         overflow: hidden;
+    }
+    img.photo {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
     }
     .initials {
         font-family: var(--font-display);

--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -66,7 +66,9 @@
                     <span>Resume</span>
                 </a>
             {/if}
-            <a class="cta" href={site.social.email}>Let's talk</a>
+            {#if site.social.email}
+                <a class="cta" href={site.social.email}>Let's talk</a>
+            {/if}
         </div>
     </div>
 </header>

--- a/src/lib/data/site.js
+++ b/src/lib/data/site.js
@@ -1,14 +1,17 @@
+import { env } from '$env/dynamic/public';
+
 export const site = {
     name: 'Sumit Rai',
     role: 'Sr Principal Software Engineer at Yahoo',
     tagline: 'Building scalable web experiences at global scale.',
     bio: 'I lead frontend architecture and engineering for large-audience web products. I care about craft, performance, and teams that ship with clarity.',
     location: 'Sunnyvale, CA',
-    resume: null,
+    profilePicture: env.PUBLIC_PROFILE_PICTURE_URL || null,
+    resume: env.PUBLIC_RESUME_URL || null,
     social: {
-        github: 'https://github.com/itssumitrai',
-        linkedin: 'https://www.linkedin.com/in/sumitrai1987/',
-        email: 'mailto:hello@example.com'
+        github: env.PUBLIC_GITHUB_URL || null,
+        linkedin: env.PUBLIC_LINKEDIN_URL || null,
+        email: env.PUBLIC_EMAIL ? `mailto:${env.PUBLIC_EMAIL}` : null
     },
     nav: [
         { label: 'About', href: '#about' },


### PR DESCRIPTION
## Summary
- `src/lib/data/site.js` now reads email, GitHub URL, LinkedIn URL, profile picture URL, and resume URL from `$env/dynamic/public` at build time instead of having them hardcoded.
- Missing values degrade gracefully (CTAs that need email are hidden; profile picture falls back to the "SR" initials placeholder; Resume button stays hidden).
- Both CI and deploy workflows pass the `PUBLIC_*` values from repo-level **Variables** to the build step.

## Why
Keeps personal info (real email, links, picture URL) out of the repo source; allows different values per environment; makes it easy to change without touching code.

## Action required before merging
1. Open repo **Settings → Secrets and variables → Actions → Variables** tab (the *Variables* tab, not *Secrets*, since these are inlined into public HTML anyway).
2. Add:
   - `PUBLIC_EMAIL` — bare address, e.g. `you@example.com`
   - `PUBLIC_GITHUB_URL`
   - `PUBLIC_LINKEDIN_URL`
   - `PUBLIC_PROFILE_PICTURE_URL` (leave unset to keep initials fallback)
   - `PUBLIC_RESUME_URL` (leave unset to hide the Resume button)

Until those are set, the deployed site will render without the email CTAs, socials, profile picture, or resume button — the page still builds and works.

## Local dev
\`\`\`
cp .env.example .env
# edit .env with your values
npm run dev
\`\`\`

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean with no env (CTAs + socials hidden; initials shown; resume button hidden)
- [x] `npm run build` clean with full env (links rendered; profile picture `<img>` shown; resume button visible)
- [x] `.env` does not appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)